### PR TITLE
improve performance

### DIFF
--- a/memoize_test.go
+++ b/memoize_test.go
@@ -180,14 +180,14 @@ func TestDoCancel(t *testing.T) {
 	// wait for goroutine 1 and 2 to be blocked by fn
 	for {
 		time.Sleep(time.Millisecond)
-		g.mu.Lock()
-		e := g.m["key"]
-		e.mu.RLock()
-		runs := e.call.runs
-		e.mu.RUnlock()
-		g.mu.Unlock()
-		if runs == 2 {
-			break
+		if e, ok := g.m.Load("key"); ok {
+			e := e.(*entry[any])
+			e.mu.RLock()
+			runs := e.call.runs
+			e.mu.RUnlock()
+			if runs == 2 {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/memoize
            │   .old.txt   │              .new.txt               │
            │    sec/op    │   sec/op     vs base                │
Do/1-10       289.40n ± 1%   55.86n ± 6%  -80.70% (p=0.000 n=10)
Do/10-10      281.30n ± 1%   41.62n ± 2%  -85.20% (p=0.000 n=10)
Do/100-10     220.30n ± 3%   36.98n ± 1%  -83.21% (p=0.000 n=10)
Do/1000-10    243.40n ± 4%   33.99n ± 5%  -86.03% (p=0.000 n=10)
Do/10000-10   241.85n ± 9%   31.32n ± 5%  -87.05% (p=0.000 n=10)
geomean        253.9n        39.11n       -84.60%

            │   .old.txt   │               .new.txt                │
            │     B/op     │    B/op      vs base                  │
Do/1-10        0.00 ± 0%      64.00 ± 0%          ? (p=0.000 n=10)
Do/10-10       0.00 ± 0%      64.00 ± 0%          ? (p=0.000 n=10)
Do/100-10     5.000 ± 0%     64.000 ± 0%  +1180.00% (p=0.000 n=10)
Do/1000-10    34.50 ± 4%      64.00 ± 2%    +85.51% (p=0.000 n=10)
Do/10000-10   39.00 ± 5%      65.00 ± 0%    +66.67% (p=0.000 n=10)
geomean                  ¹    64.20       ?
¹ summaries must be >0 to compute geomean

            │   .old.txt   │           .new.txt           │
            │  allocs/op   │ allocs/op   vs base          │
Do/1-10       0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
Do/10-10      0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
Do/100-10     0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
Do/1000-10    0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
Do/10000-10   0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
geomean                  ¹   1.000       ?
¹ summaries must be >0 to compute geomean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency and concurrency handling in caching mechanisms.
	- Enhanced testing for concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->